### PR TITLE
fix umap crash

### DIFF
--- a/UtocEmulator/fileemu-utoc-stream-emulator/src/asset_collector.rs
+++ b/UtocEmulator/fileemu-utoc-stream-emulator/src/asset_collector.rs
@@ -276,7 +276,7 @@ pub fn add_from_folders_inner(parent: TocDirectorySyncRef, os_path: &PathBuf, pr
                                 // it's a matter of either replacing an existing file or adding a new file
                                 // ,,,at least until we start thinking about merging P3RE persona tables (lol)
                                 Some(io_ext) => {
-                                    if *io_ext == "uasset" { // export bundles - requires checking file header to ensure that it doesn't have the cooked asset signature
+                                    if *io_ext == "uasset" || *io_ext == "umap" { // export bundles - requires checking file header to ensure that it doesn't have the cooked asset signature
                                         let current_file = File::open(fs_obj.path().to_str().unwrap()).unwrap();
                                         let mut file_reader = BufReader::with_capacity(4, current_file);
                                         if !io_package::is_valid_asset_type::<BufReader<File>, byteorder::NativeEndian>(&mut file_reader) {

--- a/UtocEmulator/fileemu-utoc-stream-emulator/src/toc_factory.rs
+++ b/UtocEmulator/fileemu-utoc-stream-emulator/src/toc_factory.rs
@@ -146,7 +146,7 @@ pub trait TocResolverCommon { // Currently for 4.25+, 4.26 and 4.27
             ) {
             Some(io_ext) => {
                 match *io_ext {
-                    "uasset" => IoChunkType4::ExportBundleData, //.uasset
+                    "uasset" | "umap" => IoChunkType4::ExportBundleData, //.uasset, .umap
                     "ubulk" => IoChunkType4::BulkData, // .ubulk
                     "uptnl" => IoChunkType4::OptionalBulkData, // .uptnl
                     _ => panic!("CRITICAL ERROR: Did not get a supported file extension. This should've been handled earlier")


### PR DESCRIPTION
.umap files would cause Reloaded to crash since toc_factory claimed that it was an unsupported file extension.